### PR TITLE
ENH: reference workflow N4 improvements

### DIFF
--- a/fprodents/workflows/base.py
+++ b/fprodents/workflows/base.py
@@ -306,7 +306,9 @@ tasks and sessions), the following preprocessing was performed.
 
         bold_ref_wf = init_epi_reference_wf(
             auto_bold_nss=True,
-            omp_nthreads=config.nipype.omp_nthreads
+            omp_nthreads=config.nipype.omp_nthreads,
+            n4_iter=4,
+            adaptive_bspline_grid=True,
         )
         bold_ref_wf.inputs.inputnode.in_files = (
             bold_file if not multiecho else bold_file[0]

--- a/fprodents/workflows/base.py
+++ b/fprodents/workflows/base.py
@@ -306,6 +306,8 @@ tasks and sessions), the following preprocessing was performed.
 
         bold_ref_wf = init_epi_reference_wf(
             auto_bold_nss=True,
+            adaptive_bspline_grid=True,
+            n4_iter=4,
             omp_nthreads=config.nipype.omp_nthreads
         )
         bold_ref_wf.inputs.inputnode.in_files = (

--- a/fprodents/workflows/base.py
+++ b/fprodents/workflows/base.py
@@ -306,16 +306,11 @@ tasks and sessions), the following preprocessing was performed.
 
         bold_ref_wf = init_epi_reference_wf(
             auto_bold_nss=True,
-            adaptive_bspline_grid=True,
-            n4_iter=4,
             omp_nthreads=config.nipype.omp_nthreads
         )
         bold_ref_wf.inputs.inputnode.in_files = (
             bold_file if not multiecho else bold_file[0]
         )
-
-        # brain extraction on reference file
-        brain_extraction_wf = init_rodent_brain_extraction_wf(ants_affine_init=False)
 
         func_preproc_wf = init_func_preproc_wf(bold_file)
 
@@ -329,10 +324,6 @@ tasks and sessions), the following preprocessing was performed.
               ('outputnode.template', 'inputnode.template'),
               ('outputnode.anat2std_xfm', 'inputnode.anat2std_xfm'),
               ('outputnode.std2anat_xfm', 'inputnode.std2anat_xfm')]),
-            (bold_ref_wf, brain_extraction_wf, [
-                ('outputnode.epi_ref_file', 'inputnode.in_files')]),
-            (brain_extraction_wf, func_preproc_wf,
-             [("outputnode.out_mask", "inputnode.bold_mask")]),
             (bold_ref_wf, func_preproc_wf,
              [('outputnode.epi_ref_file', 'inputnode.ref_file'),
               ('outputnode.xfm_files', 'inputnode.bold_ref_xfm'),

--- a/fprodents/workflows/base.py
+++ b/fprodents/workflows/base.py
@@ -108,7 +108,6 @@ def init_single_subject_wf(subject_id):
     from niworkflows.utils.connections import listify
     from niworkflows.utils.spaces import Reference
     from niworkflows.workflows.epi.refmap import init_epi_reference_wf
-    from nirodents.workflows.brainextraction import init_rodent_brain_extraction_wf
     from ..patch.interfaces import BIDSDataGrabber
     from ..patch.utils import extract_entities, fix_multi_source_name
     from ..patch.workflows.anatomical import init_anat_preproc_wf

--- a/fprodents/workflows/bold/base.py
+++ b/fprodents/workflows/bold/base.py
@@ -437,7 +437,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     # fmt:off
     workflow.connect([
         (inputnode, bold_reg_wf, [('anat_preproc', 'inputnode.t1w_brain'),
-                                ('ref_file', 'inputnode.ref_bold_brain')]),
+                                  ('ref_file', 'inputnode.ref_bold_brain')]),
         (inputnode, t1w_brain, [('anat_preproc', 'in_file'),
                                 ('anat_mask', 'in_mask')]),
         # convert bold reference LTA transform to other formats

--- a/fprodents/workflows/bold/base.py
+++ b/fprodents/workflows/bold/base.py
@@ -469,6 +469,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         (bold_confounds_wf, outputnode, [('outputnode.confounds_file', 'confounds')]),
         (bold_confounds_wf, outputnode, [('outputnode.confounds_metadata', 'confounds_metadata')]),
         # Connect bold_bold_trans_wf
+        (inputnode, bold_bold_trans_wf, [('ref_file', 'inputnode.bold_ref')]),
         (t1w_mask_bold_tfm, bold_bold_trans_wf, [('output_image', 'inputnode.bold_mask')]),
         (bold_split, bold_bold_trans_wf, [('out_files', 'inputnode.bold_file')]),
         (lta_convert, bold_bold_trans_wf, [('out_itk', 'inputnode.hmc_xforms')]),

--- a/fprodents/workflows/bold/registration.py
+++ b/fprodents/workflows/bold/registration.py
@@ -105,10 +105,12 @@ Co-registration was configured with six degrees of freedom.
     )
 
     coreg = pe.Node(
-        FLIRTRPT(dof=bold2t1w_dof,
+        FLIRTRPT(
+            dof=bold2t1w_dof,
             generate_report=True,
             uses_qform=True,
-            args="-basescale 1"),
+            args="-basescale 1"
+        ),
         name="coreg")
 
     if bold2t1w_init not in ("register", "header"):

--- a/fprodents/workflows/bold/registration.py
+++ b/fprodents/workflows/bold/registration.py
@@ -108,9 +108,7 @@ Co-registration was configured with six degrees of freedom.
         FLIRTRPT(
             dof=bold2t1w_dof,
             generate_report=True,
-            uses_qform=True,
-            args="-basescale 1"
-        ),
+            uses_qform=True),
         name="coreg")
 
     if bold2t1w_init not in ("register", "header"):

--- a/fprodents/workflows/bold/resampling.py
+++ b/fprodents/workflows/bold/resampling.py
@@ -399,7 +399,9 @@ the transforms to correct for head-motion"""
     workflow.connect([
         (inputnode, merge, [('name_source', 'header_source')]),
         (bold_transform, merge, [('out_files', 'in_files')]),
-        (inputnode, bold_transform, [(('hmc_xforms', listify), 'transforms')]),
+        (inputnode, bold_transform, [
+            (('hmc_xforms', listify), 'transforms'),
+            ('bold_ref', 'reference_image')]),
         (merge, outputnode, [('out_file', 'bold')]),
     ])
     # fmt:on
@@ -412,17 +414,13 @@ the transforms to correct for head-motion"""
         # fmt:off
         workflow.connect([
             (inputnode, bold_split, [('bold_file', 'in_file')]),
-            (bold_split, bold_transform, [
-                ('out_files', 'input_image'),
-                (('out_files', _first), 'reference_image'),
-            ])
+            (bold_split, bold_transform, [('out_files', 'input_image')])
         ])
         # fmt:on
     else:
         # fmt:off
         workflow.connect([
-            (inputnode, bold_transform, [('bold_file', 'input_image'),
-                                         (('bold_file', _first), 'reference_image')]),
+            (inputnode, bold_transform, [('bold_file', 'input_image')]),
         ])
         # fmt:on
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     nipype ~= 1.5.1
     nitime
     nitransforms ~= 21.0.0
-    niworkflows ~= 1.4.0
+    niworkflows @ git+https://github.com/nipreps/niworkflows.git@feat/infants-rodents
     nirodents >= 0.2.4
     numpy
     pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     nitime
     nitransforms ~= 21.0.0
     niworkflows @ git+https://github.com/nipreps/niworkflows.git@feat/infants-rodents
-    nirodents >= 0.2.4
+    nirodents @ git+https://github.com/nipreps/nirodents.git@feat/fmriprep-rodents
     numpy
     pandas
     pybids >= 0.12.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ url = https://github.com/poldracklab/fmriprep-rodents
 python_requires = >=3.7
 install_requires =
     nibabel >= 3.0
-    nipype ~= 1.5.1
+    nipype @ git+https://github.com/nipy/nipype.git@master
     nitime
     nitransforms ~= 21.0.0
     niworkflows @ git+https://github.com/nipreps/niworkflows.git@feat/infants-rodents


### PR DESCRIPTION
## Changes proposed in this pull request
This makes the rodent-specific arguments (made available by nipreps/niworkflows#630) available to the reference workflow for more robust N4 correction. This should make the reference image easier to mask.

Also worth noting that in this scenario, brain extraction is run only once (on the structural image), and the registration between structural and functional is run without masking.

~Also updated `FLIRTRPT` to include `--basescale 1` argument, based on the conversation had over at nipreps/fmriprep#2624, to overcome problems in coregistration when testing locally.~
EDIT: this has been removed and will be added to a separate PR

## Documentation that should be reviewed
