### PR TITLE
FIX: No BOLD images found for participant

### DIFF
--- a/fprodents/workflows/base.py
+++ b/fprodents/workflows/base.py
@@ -116,8 +116,8 @@ def init_single_subject_wf(subject_id):
     subject_data = collect_data(
         config.execution.layout,
         subject_id,
-        config.execution.task_id,
-        config.execution.echo_idx,
+        task=config.execution.task_id,
+        echo=config.execution.echo_idx,
         bids_filters=config.execution.bids_filters,
     )[0]
 


### PR DESCRIPTION
Provide a fix for #50 

## Changes proposed in this pull request
Currently fmriprep-rodents consider that the collect_data function of niworkflows has the following header:

`def collect_data(
    bids_dir,
    participant_label,
    task=None,
    echo=None,
    bids_validate=True,
    bids_filters=None,
)`

Indeed, when calling collect_data, the task and echo parameters are not defined explicitly:
`subject_data = collect_data(
        config.execution.layout,
        subject_id,
        config.execution.task_id,
        config.execution.echo_idx,
        bids_filters=config.execution.bids_filters,
    )[0]`

However,  the header of the collect_data function of niworkflows has the optional parameter session_id before the optional parameter task. 
`def collect_data(
    bids_dir,
    participant_label,
    session_id=Query.OPTIONAL,
    task=None,
    echo=None,
    bids_validate=True,
    bids_filters=None,
)`

When calling collect_data, the task and echo parameters should thus be defined explicitly:
`subject_data = collect_data(
        config.execution.layout,
        subject_id,
        task=config.execution.task_id,
        echo=config.execution.echo_idx,
        bids_filters=config.execution.bids_filters,
    )[0]`

